### PR TITLE
Use consistent naming for transformations parameter

### DIFF
--- a/activestorage/app/jobs/active_storage/create_variants_job.rb
+++ b/activestorage/app/jobs/active_storage/create_variants_job.rb
@@ -6,14 +6,14 @@ class ActiveStorage::CreateVariantsJob < ActiveStorage::BaseJob
   discard_on ActiveRecord::RecordNotFound
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
-  def perform(blob, transformations:, process:)
+  def perform(blob, transformations_array:, process:)
     @blob = blob
     @process = process
 
     @blob.preview({}).processed if preview_image_needed?
 
-    transformations.each do |transformation|
-      ActiveStorage::TransformJob.public_send(perform_method, @blob, transformation)
+    transformations_array.each do |transformations|
+      ActiveStorage::TransformJob.public_send(perform_method, @blob, transformations)
     end
   end
 

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -6,7 +6,7 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   discard_on ActiveRecord::RecordNotFound
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
-  def perform(blob, transformation)
-    blob.representation(transformation).processed
+  def perform(blob, transformations)
+    blob.representation(transformations).processed
   end
 end

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -146,8 +146,8 @@ class ActiveStorage::Attachment < ActiveStorage::Record
         end
       end
 
-      ActiveStorage::CreateVariantsJob.perform_now(blob, transformations: immediate_transformations, process: :immediately) if immediate_transformations.any?
-      ActiveStorage::CreateVariantsJob.perform_later(blob, transformations: later_transformations, process: :later) if later_transformations.any?
+      ActiveStorage::CreateVariantsJob.perform_now(blob, transformations_array: immediate_transformations, process: :immediately) if immediate_transformations.any?
+      ActiveStorage::CreateVariantsJob.perform_later(blob, transformations_array: later_transformations, process: :later) if later_transformations.any?
     end
 
     def purge_dependent_blob_later

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -95,10 +95,11 @@ class ActiveStorage::Preview
     end
   end
 
+  def processed?
+    image.attached?
+  end
+
   private
-    def processed?
-      image.attached?
-    end
 
     def process
       previewer.preview(service_name: blob.service_name) do |attachable|

--- a/activestorage/test/jobs/create_variants_job_test.rb
+++ b/activestorage/test/jobs/create_variants_job_test.rb
@@ -5,41 +5,41 @@ require "database/setup"
 
 class ActiveStorage::CreateVariantsJobTest < ActiveJob::TestCase
   setup do
-    @transformations = [{ resize_to_limit: [ 100, 100 ] }, { resize_to_limit: [ 200, 200 ] }]
+    @transformations_array = [{ resize_to_limit: [ 100, 100 ] }, { resize_to_limit: [ 200, 200 ] }]
   end
 
   test "creates preview when previewable" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
 
     assert_changes -> { blob.preview_image.attached? }, from: false, to: true do
-      ActiveStorage::CreateVariantsJob.perform_now blob, process: :later, transformations: @transformations
+      ActiveStorage::CreateVariantsJob.perform_now blob, transformations_array: @transformations_array, process: :later
     end
   end
 
   test "enqueues individual transform jobs for each transformation when process: :later" do
     blob = create_file_blob
-    ActiveStorage::CreateVariantsJob.perform_now blob, process: :later, transformations: @transformations
+    ActiveStorage::CreateVariantsJob.perform_now blob, transformations_array: @transformations_array, process: :later
 
-    @transformations.each do |transformation|
-      assert_enqueued_with job: ActiveStorage::TransformJob, args: [ blob, transformation ]
+    @transformations_array.each do |transformations|
+      assert_enqueued_with job: ActiveStorage::TransformJob, args: [ blob, transformations ]
     end
   end
 
   test "does not transform when process: :later" do
     blob = create_file_blob
-    ActiveStorage::CreateVariantsJob.perform_now blob, process: :later, transformations: @transformations
+    ActiveStorage::CreateVariantsJob.perform_now blob, transformations_array: @transformations_array, process: :later
 
-    @transformations.each do |transformation|
-      assert_not blob.variant(transformation).processed?
+    @transformations_array.each do |transformations|
+      assert_not blob.variant(transformations).processed?
     end
   end
 
   test "performs transformations immediately when process: :immediately" do
     blob = create_file_blob
-    ActiveStorage::CreateVariantsJob.perform_now blob, process: :immediately, transformations: @transformations
+    ActiveStorage::CreateVariantsJob.perform_now blob, transformations_array: @transformations_array, process: :immediately
 
-    @transformations.each do |transformation|
-      assert blob.variant(transformation).processed?
+    @transformations_array.each do |transformations|
+      assert blob.variant(transformations).processed?
     end
   end
 end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -194,7 +194,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
 
   test "enqueues create variants job to delay transformations after attach" do
     blob = create_file_blob
-    assert_create_variants_job blob:, transformation: { resize_to_limit: [2, 2] } do
+    assert_create_variants_job blob:, transformations_array: [{ resize_to_limit: [2, 2] }] do
       @user.avatar_with_later_variants.attach blob
     end
   end
@@ -250,10 +250,10 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
       assert_equal 0, (max_transaction_depth - baseline_transaction_depth)
     end
 
-    def assert_create_variants_job(blob:, transformation:, &block)
+    def assert_create_variants_job(blob:, transformations_array:, &block)
       assert_enqueued_with(
         job: ActiveStorage::CreateVariantsJob,
-        args: [ blob, transformations: [transformation], process: :later ], &block
+        args: [ blob, transformations_array:, process: :later ], &block
       )
     end
 end


### PR DESCRIPTION
ActiveStorage uses the plural `transformations` for a single hash of transformation options (e.g., `{ resize_to_limit: [100, 100] }`).

To differentiate between a single transformation hash and an array of transformation hashes, this commit introduces `transformations_array` for arrays of transformations, while retaining transformations for individual hashes.